### PR TITLE
L3- People's possible duplicated emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'fuzzy-string-match'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    RubyInline (3.12.5)
+      ZenTest (~> 4.3)
+    ZenTest (4.12.0)
     actioncable (6.1.4)
       actionpack (= 6.1.4)
       activesupport (= 6.1.4)
@@ -81,6 +84,8 @@ GEM
     crass (1.0.6)
     erubi (1.10.0)
     ffi (1.15.3)
+    fuzzy-string-match (1.0.1)
+      RubyInline (>= 3.8.6)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)
@@ -211,6 +216,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  fuzzy-string-match
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/duplicated_emails_controller.rb
+++ b/app/controllers/duplicated_emails_controller.rb
@@ -1,0 +1,5 @@
+class DuplicatedEmailsController < ApplicationController
+  def index
+    @list = DuplicatedStringsService.new(api.list_emails).fetch_list
+  end
+end

--- a/app/services/duplicated_strings_service.rb
+++ b/app/services/duplicated_strings_service.rb
@@ -1,0 +1,38 @@
+class DuplicatedStringsService
+  attr_reader :list, :fuzzy
+  attr_accessor :strings
+
+  def initialize(strings)
+    @list = Hash.new { |hash, key| hash[key] = [] }
+    @strings = strings
+    initialize_fuzzy
+    iterate_key_strings
+  end
+
+  def fetch_list
+    list
+  end
+
+  private
+
+  def initialize_fuzzy
+    @fuzzy = FuzzyStringMatchService.new
+  end
+
+  def close?(string1, string2)
+    fuzzy.close_match?(string1, string2)
+  end
+
+  def iterate_key_strings
+    strings.each do |string|
+      iterate_value_substrings(string)
+    end
+  end
+
+  def iterate_value_substrings(reference_string)
+    strings.delete_if do |compare_string|
+      next if reference_string === compare_string
+      list[reference_string] += [compare_string] if close?(reference_string, compare_string)
+    end
+  end
+end

--- a/app/services/fuzzy_string_match_service.rb
+++ b/app/services/fuzzy_string_match_service.rb
@@ -1,0 +1,21 @@
+require 'fuzzystringmatch'
+
+class FuzzyStringMatchService
+  MATCH_DISTANCE = 0.9
+
+  attr_reader :jarow
+
+  def initialize
+    @jarow = FuzzyStringMatch::JaroWinkler.create( :native )
+  end
+
+  def close_match?(string1, string2)
+    get_distance(string1, string2) > MATCH_DISTANCE
+  end
+
+  private
+
+  def get_distance(string1, string2)
+    jarow.getDistance(string1, string2)
+  end
+end

--- a/app/views/duplicated_emails/index.html.erb
+++ b/app/views/duplicated_emails/index.html.erb
@@ -1,0 +1,21 @@
+<h1>Salesloft people's duplicated emails </h1>
+
+<%= link_to :back, root_path %>
+
+<table>
+  <tr>
+    <th> Reference email </th>
+    <th> Possible duplicated emails </th>
+  </tr>
+  <% @list.each do |key, value| %>
+    <tr>
+      <td>
+        <span> <%= key  %></span>
+      </td>
+      <td>
+        <span> <%= value %></span>
+      </td>
+    </tr>
+  <% end %>
+</table>
+

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,6 +1,7 @@
 <h1>Salesloft people</h1>
 
 <%= link_to "Character counter", characters_path %>
+<%= link_to "Duplicated emails", duplicated_emails_path %>
 
 <table>
   <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root to: 'people#index'
 
   resources :characters, only: %i[index]
+  resources :duplicated_emails, only: %i[index]
 end

--- a/test/controllers/duplicated_emails_controller_test.rb
+++ b/test/controllers/duplicated_emails_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class CharactersControllerTest < ActionDispatch::IntegrationTest
+class DuplicatedEmailsControllerTest < ActionDispatch::IntegrationTest
   test 'test_index_success_response' do
-    get characters_path
+    get duplicated_emails_path
     assert_response :success
     assert assigns(:list)
   end

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PeopleControllerTest < ActionDispatch::IntegrationTest
-  test 'test_index_success_reponse' do
+  test 'test_index_success_response' do
     get root_path
     assert_response :success
     assert assigns(:people)

--- a/test/services/duplicated_strings_service.rb
+++ b/test/services/duplicated_strings_service.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class DuplicatedStringsServiceTest < ActiveSupport::TestCase
+  test 'result list with one coincidences' do
+    dstrings = DuplicatedStringsService.new(["san@gmail.com", "zan@gmail.com", "andy@gmail.com"])
+    list = dstrings.fetch_list
+    assert_equal "san@gmail.com", list.keys.first
+    assert_equal ["zan@gmail.com", "andy@gmail.com"], list["san@gmail.com"]
+  end
+
+  test 'result list with two coincidences' do
+    dstrings = DuplicatedStringsService.new(["san@gmail.com", "zan@gmail.com", "andy@gmail.com", "ruby87@gmail.com", "ggruby8@gmail.com", "ruby86@gmail.com"])
+    list = dstrings.fetch_list
+    assert_equal "san@gmail.com", list.keys.first
+    assert_equal ["zan@gmail.com", "andy@gmail.com"], list["san@gmail.com"]
+    assert_equal "ruby87@gmail.com", list.keys.second
+    assert_equal ["ruby86@gmail.com"], list["ruby87@gmail.com"]
+  end
+
+  test 'result list with any coincidences' do
+    dstrings = DuplicatedStringsService.new(["san@gmail.com", "karla@gmail.com", "karen2611@gmail.com"])
+    list = dstrings.fetch_list
+    assert_equal 0, list.keys.count
+  end
+end

--- a/test/services/fuzzy_string_match_service_test.rb
+++ b/test/services/fuzzy_string_match_service_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class FuzzyStringMatchServiceTest < ActiveSupport::TestCase
+  test 'close_match?' do
+    fuzzy = FuzzyStringMatchService.new
+    assert fuzzy.close_match?("sandrely2611@gmail.com", "sandrely2612@gmail.com")
+    refute fuzzy.close_match?("ruby@gmail.com", "edgar@gmail.com")
+  end
+end


### PR DESCRIPTION
**This MR includes:**

-Services to evaluate the distance between strings and compare them to know if is a possible match or duplication.
Note: The gem added "fuzzy-string-match" makes all the magic for the `Jaro-Winkler distance algorithm.`
For more info: https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance

-New duplicated_emails_controller.rb to handle the render list of the DuplicatedStringsService. Consider that the response is hash, the key is the reference email and the value is the possible matches.

**The table looks like the following:**
<img width="570" alt="Screen Shot 2021-07-09 at 12 54 58" src="https://user-images.githubusercontent.com/9082790/125118418-49652580-e0b5-11eb-8e97-70467e411c13.png">
